### PR TITLE
Reordered EXTI reset code in HAL_GPIO_DeInit()

### DIFF
--- a/Src/stm32l0xx_hal_gpio.c
+++ b/Src/stm32l0xx_hal_gpio.c
@@ -306,6 +306,24 @@ void HAL_GPIO_DeInit(GPIO_TypeDef  *GPIOx, uint32_t GPIO_Pin)
 
     if(iocurrent)
     {
+      /*------------------------- EXTI Mode Configuration --------------------*/
+      /* Clear the External Interrupt or Event for the current IO */
+      tmp = SYSCFG->EXTICR[position >> 2U];
+      tmp &= (((uint32_t)0x0FU) << (4U * (position & 0x03U)));
+      if(tmp == (GPIO_GET_INDEX(GPIOx) << (4U * (position & 0x03U))))
+      {
+        /* Clear EXTI line configuration */
+        EXTI->IMR &= ~((uint32_t)iocurrent);
+        EXTI->EMR &= ~((uint32_t)iocurrent);
+        
+        /* Clear Rising Falling edge configuration */
+        EXTI->RTSR &= ~((uint32_t)iocurrent);
+        EXTI->FTSR &= ~((uint32_t)iocurrent);
+        
+        tmp = ((uint32_t)0x0FU) << (4U * (position & 0x03U));
+        SYSCFG->EXTICR[position >> 2U] &= ~tmp;
+      }
+
       /*------------------------- GPIO Mode Configuration --------------------*/
       /* Configure IO Direction in Input Floting Mode */
       GPIOx->MODER |= (GPIO_MODER_MODE0 << (position * 2U));
@@ -322,24 +340,6 @@ void HAL_GPIO_DeInit(GPIO_TypeDef  *GPIOx, uint32_t GPIO_Pin)
       /* Deactivate the Pull-up oand Pull-down resistor for the current IO */
       GPIOx->PUPDR &= ~(GPIO_PUPDR_PUPD0 << (position * 2U));
       
-      /*------------------------- EXTI Mode Configuration --------------------*/
-      /* Clear the External Interrupt or Event for the current IO */
-      
-      tmp = SYSCFG->EXTICR[position >> 2U];
-      tmp &= (((uint32_t)0x0FU) << (4U * (position & 0x03U)));
-      if(tmp == (GPIO_GET_INDEX(GPIOx) << (4U * (position & 0x03U))))
-      {
-        tmp = ((uint32_t)0x0FU) << (4U * (position & 0x03U));
-        SYSCFG->EXTICR[position >> 2U] &= ~tmp;
-
-        /* Clear EXTI line configuration */
-        EXTI->IMR &= ~((uint32_t)iocurrent);
-        EXTI->EMR &= ~((uint32_t)iocurrent);
-
-        /* Clear Rising Falling edge configuration */
-        EXTI->RTSR &= ~((uint32_t)iocurrent);
-        EXTI->FTSR &= ~((uint32_t)iocurrent);
-      }
     }
      position++;
   }


### PR DESCRIPTION
Scenario:
Firmware configures a GPIO for EXTI line interrupt on falling edge. In
hardware the GPIO is pulled to Vdd by a pull-up resistor. After the
falling edge is detected (single instance), the firmware reconfigures
the GPIO pin for a different purpose.

Problem:
EXTI line interrupt is triggered twice, while in fact only one falling
edge is generated on the I/O pin.

Root cause:
Improper EXTI reset order in HAL_GPIO_DeInit(). After the first time the
EXTI line interrupt is fired, the firmware calls HAL_GPIO_DeInit() to
de-initialize the GPIO pin because the resource is not needed anymore.
Because the way the code is ordered in HAL_GPIO_DeInit(), '1'-to-'0'
transition might be arise in the "Input data register" because the
mode is reset to Analog High Impedance mode. This disable the internal
Schmitt trigger, which continuously produces a '0' on its output.
If the I/O was pulled high by pull-up resistor, a '1'-to-'0' transition
triggers the EXTI line edge detector and fires the IRQ because the EXTI
line configuration registers are not yet reset at this point in
HAL_GPIO_DeInit().

Solution:
Reorder the EXTI reset code in HAL_GPIO_DeInit() to disable the EXIT
line interrupt before switching the value of EXTI line multiplexer and
resetting the mode of the GPIO pin to analog high-impedance mode.

Fixes #1.

## IMPORTANT INFORMATION

### Contributor License Agreement (CLA)
* The Pull Request feature will be considered by STMicroelectronics after the signature of a **Contributor License Agreement (CLA)** by the submitter.
* If you did not sign such agreement, please follow the steps mentioned in the CONTRIBUTING.md file.
